### PR TITLE
unpin dependencies in environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,8 @@ name: voila-gallery-country-indicators
 channels:
 - conda-forge
 dependencies:
-- matplotlib=3.4.3
-- pandas=1.3.2
-- ipywidgets=7.6
-- jupyterlab=3.1
-- voila=0.2.11
-
+- matplotlib-base
+- pandas
+- ipywidgets
+- jupyterlab>=3.1
+- voila>=0.2.11


### PR DESCRIPTION
avoids broken env due to partial pinning

also switched `matplotlib` to `matplotlib-base` which skips the dependency on qt, etc.